### PR TITLE
chore(deps): bump pillow & starlette to fix security advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ pandas==2.3.1
 pathlib==1.0.1
 pexpect==4.9.0
 phonenumbers==9.0.10
-pillow==11.2.1
+pillow==11.3.0
 platformdirs==4.3.8
 pluggy==1.6.0
 pre_commit==4.2.0
@@ -85,7 +85,7 @@ six==1.17.0
 sniffio==1.3.1
 soupsieve==2.7
 SQLAlchemy==2.0.42
-starlette==0.47.1
+starlette==0.47.2
 tomlkit==0.13.3
 tqdm==4.67.1
 typer==0.16.0


### PR DESCRIPTION
Bumps pillow -> 11.3.0 and starlette -> 0.47.2 to address pip-audit findings. CI run and tests required.